### PR TITLE
Rename ApiClientOptions to ClientOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ dotnet add package Unsplash.Net
 Import and initialize the client using the public authentication token created above.
 
 ```csharp
-var client = new UnsplashClient(new ApiClientOptions
+var client = new UnsplashClient(new ClientOptions
 {
     AccessKey = "<Token>"
 });

--- a/src/Unsplash.Tests/CollectionsApiTests.cs
+++ b/src/Unsplash.Tests/CollectionsApiTests.cs
@@ -40,7 +40,7 @@ namespace Unsplash.Tests
                     .WithBody(jsonData)
             );
 
-            var client = new CollectionsApi(new ApiClientOptions
+            var client = new CollectionsApi(new ClientOptions
             {
                 BaseUrl = _server.Urls[0],
                 AccessKey = ACCESS_KEY
@@ -73,7 +73,7 @@ namespace Unsplash.Tests
                     .WithBody(jsonData)
             );
 
-            var client = new CollectionsApi(new ApiClientOptions
+            var client = new CollectionsApi(new ClientOptions
             {
                 BaseUrl = _server.Urls[0],
                 AccessKey = ACCESS_KEY
@@ -106,7 +106,7 @@ namespace Unsplash.Tests
                     .WithBody(jsonData)
             );
 
-            var client = new CollectionsApi(new ApiClientOptions
+            var client = new CollectionsApi(new ClientOptions
             {
                 BaseUrl = _server.Urls[0],
                 AccessKey = ACCESS_KEY
@@ -139,7 +139,7 @@ namespace Unsplash.Tests
                     .WithBody(jsonData)
             );
 
-            var client = new CollectionsApi(new ApiClientOptions
+            var client = new CollectionsApi(new ClientOptions
             {
                 BaseUrl = _server.Urls[0],
                 AccessKey = ACCESS_KEY

--- a/src/Unsplash.Tests/PhotosApiTests.cs
+++ b/src/Unsplash.Tests/PhotosApiTests.cs
@@ -48,7 +48,7 @@ namespace Unsplash.Tests
                     .WithBody(jsonData)
                 );
 
-            var client = new PhotosApi(new ApiClientOptions
+            var client = new PhotosApi(new ClientOptions
             {
                 BaseUrl = _server.Urls[0],
                 AccessKey = ACCESS_KEY
@@ -74,7 +74,7 @@ namespace Unsplash.Tests
                     .WithBody(jsonData)
                 );
 
-            var client = new PhotosApi(new ApiClientOptions
+            var client = new PhotosApi(new ClientOptions
             {
                 BaseUrl = _server.Urls[0],
                 AccessKey = ACCESS_KEY
@@ -103,7 +103,7 @@ namespace Unsplash.Tests
                     .WithBody(jsonData)
                 );
 
-            var client = new PhotosApi(new ApiClientOptions
+            var client = new PhotosApi(new ClientOptions
             {
                 BaseUrl = _server.Urls[0],
                 AccessKey = ACCESS_KEY
@@ -129,7 +129,7 @@ namespace Unsplash.Tests
                     .WithBody(jsonData)
                 );
 
-            var client = new PhotosApi(new ApiClientOptions
+            var client = new PhotosApi(new ClientOptions
             {
                 BaseUrl = _server.Urls[0],
                 AccessKey = ACCESS_KEY
@@ -159,7 +159,7 @@ namespace Unsplash.Tests
                     .WithBody(jsonData)
                 );
 
-            var client = new PhotosApi(new ApiClientOptions
+            var client = new PhotosApi(new ClientOptions
             {
                 BaseUrl = _server.Urls[0],
                 AccessKey = ACCESS_KEY

--- a/src/Unsplash.Tests/SearchApiTests.cs
+++ b/src/Unsplash.Tests/SearchApiTests.cs
@@ -45,7 +45,7 @@ namespace Unsplash.Tests
                     .WithBody(jsonData)
                 );
 
-            ISearchApi client = new SearchApi(new ApiClientOptions
+            ISearchApi client = new SearchApi(new ClientOptions
             {
                 BaseUrl = _server.Urls[0],
                 AccessKey = ACCESS_KEY
@@ -74,7 +74,7 @@ namespace Unsplash.Tests
                     .WithBody(jsonData)
                 );
 
-            ISearchApi client = new SearchApi(new ApiClientOptions
+            ISearchApi client = new SearchApi(new ClientOptions
             {
                 BaseUrl = _server.Urls[0],
                 AccessKey = ACCESS_KEY
@@ -103,7 +103,7 @@ namespace Unsplash.Tests
                     .WithBody(jsonData)
                 );
 
-            ISearchApi client = new SearchApi(new ApiClientOptions
+            ISearchApi client = new SearchApi(new ClientOptions
             {
                 BaseUrl = _server.Urls[0],
                 AccessKey = ACCESS_KEY

--- a/src/Unsplash.Tests/StatsApiTests.cs
+++ b/src/Unsplash.Tests/StatsApiTests.cs
@@ -46,7 +46,7 @@ namespace Unsplash.Tests
                     .WithBody(jsonData)
                 );
 
-            var client = new StatsApi(new ApiClientOptions
+            var client = new StatsApi(new ClientOptions
             {
                 BaseUrl = _server.Urls[0],
                 AccessKey = ACCESS_KEY
@@ -74,7 +74,7 @@ namespace Unsplash.Tests
                     .WithBody(jsonData)
                 );
 
-            var client = new StatsApi(new ApiClientOptions
+            var client = new StatsApi(new ClientOptions
             {
                 BaseUrl = _server.Urls[0],
                 AccessKey = ACCESS_KEY

--- a/src/Unsplash.Tests/TopicsApiTests.cs
+++ b/src/Unsplash.Tests/TopicsApiTests.cs
@@ -24,7 +24,7 @@ namespace Unsplash.Tests
                 Response.Create().WithStatusCode(200).WithBody(jsonData)
             );
 
-            var client = new TopicsApi(new ApiClientOptions
+            var client = new TopicsApi(new ClientOptions
             {
                 BaseUrl = Server.Urls[0],
                 AccessKey = ACCESS_KEY
@@ -51,7 +51,7 @@ namespace Unsplash.Tests
                 Response.Create().WithStatusCode(200).WithBody(jsonData)
             );
 
-            var client = new TopicsApi(new ApiClientOptions
+            var client = new TopicsApi(new ClientOptions
             {
                 BaseUrl = Server.Urls[0],
                 AccessKey = ACCESS_KEY
@@ -78,7 +78,7 @@ namespace Unsplash.Tests
                 Response.Create().WithStatusCode(200).WithBody(jsonData)
             );
 
-            var client = new TopicsApi(new ApiClientOptions
+            var client = new TopicsApi(new ClientOptions
             {
                 BaseUrl = Server.Urls[0],
                 AccessKey = ACCESS_KEY

--- a/src/Unsplash.Tests/UsersApiTests.cs
+++ b/src/Unsplash.Tests/UsersApiTests.cs
@@ -26,7 +26,7 @@ namespace Unsplash.Tests
                 Response.Create().WithStatusCode(200).WithBody(jsonData)
             );
 
-            var client = new UsersApi(new ApiClientOptions
+            var client = new UsersApi(new ClientOptions
             {
                 BaseUrl = Server.Urls[0],
                 AccessKey = ACCESS_KEY
@@ -53,7 +53,7 @@ namespace Unsplash.Tests
                 Response.Create().WithStatusCode(200).WithBody(jsonData)
             );
 
-            var client = new UsersApi(new ApiClientOptions
+            var client = new UsersApi(new ClientOptions
             {
                 BaseUrl = Server.Urls[0],
                 AccessKey = ACCESS_KEY
@@ -81,7 +81,7 @@ namespace Unsplash.Tests
                 Response.Create().WithStatusCode(200).WithBody(jsonData)
             );
 
-            var client = new UsersApi(new ApiClientOptions
+            var client = new UsersApi(new ClientOptions
             {
                 BaseUrl = Server.Urls[0],
                 AccessKey = ACCESS_KEY
@@ -109,7 +109,7 @@ namespace Unsplash.Tests
                 Response.Create().WithStatusCode(200).WithBody(jsonData)
             );
 
-            var client = new UsersApi(new ApiClientOptions
+            var client = new UsersApi(new ClientOptions
             {
                 BaseUrl = Server.Urls[0],
                 AccessKey = ACCESS_KEY
@@ -137,7 +137,7 @@ namespace Unsplash.Tests
                 Response.Create().WithStatusCode(200).WithBody(jsonData)
             );
 
-            var client = new UsersApi(new ApiClientOptions
+            var client = new UsersApi(new ClientOptions
             {
                 BaseUrl = Server.Urls[0],
                 AccessKey = ACCESS_KEY
@@ -165,7 +165,7 @@ namespace Unsplash.Tests
                 Response.Create().WithStatusCode(200).WithBody(jsonData)
             );
 
-            var client = new UsersApi(new ApiClientOptions
+            var client = new UsersApi(new ClientOptions
             {
                 BaseUrl = Server.Urls[0],
                 AccessKey = ACCESS_KEY

--- a/src/Unsplash/Api/Collections/CollectionsApi.cs
+++ b/src/Unsplash/Api/Collections/CollectionsApi.cs
@@ -8,7 +8,7 @@ namespace Unsplash.Api
 {
     public class CollectionsApi : ApiClient, ICollectionsApi
     {
-        public CollectionsApi(ApiClientOptions options) : base(options)
+        public CollectionsApi(ClientOptions options) : base(options)
         {
         }
 

--- a/src/Unsplash/Api/Photos/PhotosApi.cs
+++ b/src/Unsplash/Api/Photos/PhotosApi.cs
@@ -7,7 +7,7 @@ namespace Unsplash.Api
 {
     public class PhotosApi : ApiClient, IPhotosApi
     {
-        public PhotosApi(ApiClientOptions options) : base(options)
+        public PhotosApi(ClientOptions options) : base(options)
         {
         }
 

--- a/src/Unsplash/Api/Search/SearchApi.cs
+++ b/src/Unsplash/Api/Search/SearchApi.cs
@@ -9,7 +9,7 @@ namespace Unsplash.Api
 {
     public class SearchApi : ApiClient, ISearchApi
     {
-        public SearchApi(ApiClientOptions options) : base(options)
+        public SearchApi(ClientOptions options) : base(options)
         {
         }
 

--- a/src/Unsplash/Api/Stats/StatsApi.cs
+++ b/src/Unsplash/Api/Stats/StatsApi.cs
@@ -6,7 +6,7 @@ namespace Unsplash.Api
 {
     public class StatsApi : ApiClient, IStatsApi
     {
-        public StatsApi(ApiClientOptions options) : base(options)
+        public StatsApi(ClientOptions options) : base(options)
         {
         }
 

--- a/src/Unsplash/Api/Topics/TopicsApi.cs
+++ b/src/Unsplash/Api/Topics/TopicsApi.cs
@@ -9,7 +9,7 @@ namespace Unsplash.Api
 {
     public class TopicsApi : ApiClient, ITopicsApi
     {
-        public TopicsApi(ApiClientOptions options) : base(options)
+        public TopicsApi(ClientOptions options) : base(options)
         {
         }
 

--- a/src/Unsplash/Api/Users/UsersApi.cs
+++ b/src/Unsplash/Api/Users/UsersApi.cs
@@ -8,7 +8,7 @@ namespace Unsplash.Api
 {
     public class UsersApi : ApiClient, IUsersApi
     {
-        public UsersApi(ApiClientOptions options) : base(options)
+        public UsersApi(ClientOptions options) : base(options)
         {
         }
 

--- a/src/Unsplash/Client/ApiClient.cs
+++ b/src/Unsplash/Client/ApiClient.cs
@@ -10,9 +10,9 @@ namespace Unsplash
 {
     public abstract class ApiClient
     {
-        private ApiClientOptions _options;
+        private ClientOptions _options;
 
-        public ApiClient(ApiClientOptions options)
+        public ApiClient(ClientOptions options)
         {
             options = MergeOptions(options);
 
@@ -24,9 +24,9 @@ namespace Unsplash
             _options = options;
         }
 
-        private static ApiClientOptions MergeOptions(ApiClientOptions options)
+        private static ClientOptions MergeOptions(ClientOptions options)
         {
-            return new ApiClientOptions
+            return new ClientOptions
             {
                 BaseUrl = options.BaseUrl ?? Constants.BASE_URL,
                 AccessKey = options.AccessKey,
@@ -95,12 +95,5 @@ namespace Unsplash
                 request.Headers.Add(header.Key, header.Value);
             }
         }
-    }
-
-    public class ApiClientOptions
-    {
-        public string BaseUrl { get; set; }
-        public string AccessKey { get; set; }
-        public string ApiVersion { get; set; }
     }
 }

--- a/src/Unsplash/Client/ClientOptions.cs
+++ b/src/Unsplash/Client/ClientOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace Unsplash
+{
+    public class ClientOptions
+    {
+        public string BaseUrl { get; set; }
+        public string AccessKey { get; set; }
+        public string ApiVersion { get; set; }
+    }
+}

--- a/src/Unsplash/Client/UnsplashClient.cs
+++ b/src/Unsplash/Client/UnsplashClient.cs
@@ -4,7 +4,7 @@ namespace Unsplash
 {
     public class UnsplashClient
     {
-        public UnsplashClient(ApiClientOptions options)
+        public UnsplashClient(ClientOptions options)
         {
             Collections = new CollectionsApi(options);
             Photos = new PhotosApi(options);


### PR DESCRIPTION
Changes introduced in this PR.

- [x] Rename ApiClientOptions to ClientOptions
- [x] Update usage example in readme